### PR TITLE
Better logging on WQL syntax error.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name='wavefront_analytics',
-    version='0.2.0',
+    version='0.2.1',
     url='https://github.com/keep94/wavefront_analytics',
     author='Travis Keep',
     author_email='keep94@gmail.com',


### PR DESCRIPTION
run_queries() makes defensive copy of wql_by_metric dictionary so that if caller changes the passed dictionary later it doesn't affect the returned generator.  This fixes issues #1 and #2.